### PR TITLE
Fix static paths for GitHub Pages

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -1,7 +1,192 @@
-{% extends "base.html" %}
-{% block title %}About – Matford Manufacturing{% endblock %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About – Matford Manufacturing</title>
 
-{% block content %}
+  <!-- Your main stylesheet -->
+  <link rel="stylesheet" href="static/css/style.css" />
+
+  <!-- (optional) Google Font or Material Symbols if you still need them -->
+  <link
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400"
+    rel="stylesheet"
+  />
+
+  <!-- ─── FONT AWESOME 6.3 CDN ─── -->
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css"
+  />
+</head>
+<body>
+  <!-- ===== MASTHEAD / NAV ===== -->
+  <header class="masthead">
+    <div class="banner-inner">
+      <!-- ─── LEFT: Logo ─── -->
+      <div class="banner-logo">
+        <img
+          src="static/images/matford_logo.svg"
+          alt="Matford Manufacturing"/>
+      </div>
+        <div class="banner-cta">
+        <!-- Phone -->
+          <a class="contact-item" href="tel:+441234567890" aria-label="Call us">
+            <span class="contact-icon"><i class="fa-solid fa-phone"></i></span>
+            <span class="contact-text">+44&nbsp;1234&nbsp;567&nbsp;890</span>
+          </a>
+
+          <!-- Mail -->
+          <a class="contact-item" href="mailto:info@matfordmfg.com" aria-label="E-mail us">
+            <span class="contact-icon"><i class="fa-solid fa-envelope"></i></span>
+            <span class="contact-text">info@matfordmfg.com</span>
+          </a>
+        </div>
+    </div>
+  </header>
+
+  <!-- ─── PRIMARY NAVIGATION (Desktop) ─── -->
+  <nav>
+    <ul id="nav-menu">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+  <!-- ─── HAMBURGER TOGGLE FOR MOBILE ─── -->
+  <button class="nav-toggle" aria-label="Open navigation" aria-expanded="false">
+    <span class="nav-toggle__bar"></span>
+  </button>
+
+  <!-- ─── MOBILE DRAWER NAV ─── -->
+  <nav class="mobile-nav" aria-label="Mobile">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+ <!-- ─── CONSULTATION REQUEST MODAL (start hidden) ─── -->
+<div id="consultation-modal" class="modal-overlay hidden">
+  <div class="modal-content">
+
+    <div class="modal-brand">
+      <img src="static/images/matford_logo.svg"
+           alt="Matford Manufacturing logo" />
+    </div>
+
+    <button class="modal-close" aria-label="Close">&times;</button>
+
+    <h2>Request Free Consultation</h2>
+<form
+  id="consultForm"
+  action="#"
+  method="POST"
+  enctype="multipart/form-data"
+>
+  <!-- ── Email + Phone Side by Side ── -->
+  <div class="form-row">
+    <div class="form-group">
+      <label for="consult_email">Email address</label>
+      <input
+        type="email"
+        id="consult_email"
+        name="email"
+        placeholder="you@example.com"
+        required
+      />
+    </div>
+    <div class="form-group">
+      <label for="consult_phone">Contact number</label>
+      <input
+        type="tel"
+        id="consult_phone"
+        name="phone"
+        placeholder="+44 1234 567 890"
+      />
+    </div>
+  </div>
+
+  <!-- ── Subject ── -->
+  <div class="form-group">
+    <label for="consult_title">Subject</label>
+    <input
+      type="text"
+      id="consult_title"
+      name="title"
+      placeholder="Enter a brief subject"
+      required
+    />
+  </div>
+
+  <!-- ── Message ── -->
+  <div class="form-group">
+    <label for="consult_body">Message</label>
+    <textarea
+      id="consult_body"
+      name="body"
+      rows="4"
+      placeholder="Describe your request in detail…"
+      required
+    ></textarea>
+  </div>
+
+  <!-- ── Attachments ── -->
+  <div class="form-group">
+    <label for="consult_files">Attachments (optional)</label>
+    <input
+      type="file"
+      id="consult_files"
+      name="attachments"
+      multiple
+      accept="image/*,.pdf,.doc,.docx"
+    />
+    <small class="note">
+      You may attach images, PDFs, Word docs (up to 10 MB total).
+    </small>
+  </div>
+
+  <!-- ── Submit Button ── -->
+  <button type="submit" class="btn-primary modal-submit">
+    <i class="fa-solid fa-paper-plane"></i>
+    Send Request
+  </button>
+</form>
+
+    <!-- Success message (hidden by default) -->
+    <div id="consult_success" class="modal-success hidden">
+      <h3>Thank you!</h3>
+      <p>
+        Your consultation request has been sent. We will be in touch shortly.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+    <!-- Error message (hidden by default) -->
+    <div id="consult_error" class="modal-error hidden">
+      <h3>Oops — we hit an error</h3>
+      <!-- This <p> will get filled with the server’s error message -->
+      <p id="consult_error_message">
+        Something went wrong. Please try again later.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+  </div>
+</div>
+<!-- ─── CONSULTATION REQUEST MODAL (end) ─── -->
+
+  
+
+  <main>
+    
   <!-- Page heading -->
 <section class="page-heading about-heading">
   <h1>About Matford Manufacturing</h1>
@@ -12,7 +197,7 @@
   <div class="product-heroes-grid about-heroes-grid">
 
     <!-- Hero 1 — about1.jpg -->
-    <div class="solo-hero" style="--hero-img:url('{{ url_for('static', filename='images/about1.jpg') }}')">
+    <div class="solo-hero" style="--hero-img:url('static/images/about1.jpg')">
       <div class="solo-hero__copy">
         <h2>Our Story</h2>
         <p>
@@ -24,7 +209,7 @@
     </div>
 
     <!-- Hero 2 — about2.jpg -->
-    <div class="solo-hero" style="--hero-img:url('{{ url_for('static', filename='images/about2.jpg') }}')">
+    <div class="solo-hero" style="--hero-img:url('static/images/about2.jpg')">
       <div class="solo-hero__copy">
         <h2>What We Do</h2>
         <p>
@@ -35,7 +220,7 @@
     </div>
 
     <!-- Hero 3 — about3.jpg -->
-    <div class="solo-hero" style="--hero-img:url('{{ url_for('static', filename='images/about3.jpg') }}')">
+    <div class="solo-hero" style="--hero-img:url('static/images/about3.jpg')">
       <div class="solo-hero__copy">
         <h2>Big Enough to Cope,<br>Small Enough to Care</h2>
         <p>
@@ -48,4 +233,13 @@
     </div>
 
   </div>
-{% endblock %}
+
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Matford Manufacturing. All rights reserved.</p>
+  </footer>
+
+  <script src="static/js/consultation-modal.js"></script>
+</body>
+</html>

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -1,17 +1,199 @@
-{% extends "base.html" %}
-{% block title %}Contact Us – Matford Manufacturing{% endblock %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact Us – Matford Manufacturing</title>
 
-{% block hero %}
+  <!-- Your main stylesheet -->
+  <link rel="stylesheet" href="static/css/style.css" />
+
+  <!-- (optional) Google Font or Material Symbols if you still need them -->
+  <link
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400"
+    rel="stylesheet"
+  />
+
+  <!-- ─── FONT AWESOME 6.3 CDN ─── -->
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css"
+  />
+</head>
+<body>
+  <!-- ===== MASTHEAD / NAV ===== -->
+  <header class="masthead">
+    <div class="banner-inner">
+      <!-- ─── LEFT: Logo ─── -->
+      <div class="banner-logo">
+        <img
+          src="static/images/matford_logo.svg"
+          alt="Matford Manufacturing"/>
+      </div>
+        <div class="banner-cta">
+        <!-- Phone -->
+          <a class="contact-item" href="tel:+441234567890" aria-label="Call us">
+            <span class="contact-icon"><i class="fa-solid fa-phone"></i></span>
+            <span class="contact-text">+44&nbsp;1234&nbsp;567&nbsp;890</span>
+          </a>
+
+          <!-- Mail -->
+          <a class="contact-item" href="mailto:info@matfordmfg.com" aria-label="E-mail us">
+            <span class="contact-icon"><i class="fa-solid fa-envelope"></i></span>
+            <span class="contact-text">info@matfordmfg.com</span>
+          </a>
+        </div>
+    </div>
+  </header>
+
+  <!-- ─── PRIMARY NAVIGATION (Desktop) ─── -->
+  <nav>
+    <ul id="nav-menu">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+  <!-- ─── HAMBURGER TOGGLE FOR MOBILE ─── -->
+  <button class="nav-toggle" aria-label="Open navigation" aria-expanded="false">
+    <span class="nav-toggle__bar"></span>
+  </button>
+
+  <!-- ─── MOBILE DRAWER NAV ─── -->
+  <nav class="mobile-nav" aria-label="Mobile">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+ <!-- ─── CONSULTATION REQUEST MODAL (start hidden) ─── -->
+<div id="consultation-modal" class="modal-overlay hidden">
+  <div class="modal-content">
+
+    <div class="modal-brand">
+      <img src="static/images/matford_logo.svg"
+           alt="Matford Manufacturing logo" />
+    </div>
+
+    <button class="modal-close" aria-label="Close">&times;</button>
+
+    <h2>Request Free Consultation</h2>
+<form
+  id="consultForm"
+  action="#"
+  method="POST"
+  enctype="multipart/form-data"
+>
+  <!-- ── Email + Phone Side by Side ── -->
+  <div class="form-row">
+    <div class="form-group">
+      <label for="consult_email">Email address</label>
+      <input
+        type="email"
+        id="consult_email"
+        name="email"
+        placeholder="you@example.com"
+        required
+      />
+    </div>
+    <div class="form-group">
+      <label for="consult_phone">Contact number</label>
+      <input
+        type="tel"
+        id="consult_phone"
+        name="phone"
+        placeholder="+44 1234 567 890"
+      />
+    </div>
+  </div>
+
+  <!-- ── Subject ── -->
+  <div class="form-group">
+    <label for="consult_title">Subject</label>
+    <input
+      type="text"
+      id="consult_title"
+      name="title"
+      placeholder="Enter a brief subject"
+      required
+    />
+  </div>
+
+  <!-- ── Message ── -->
+  <div class="form-group">
+    <label for="consult_body">Message</label>
+    <textarea
+      id="consult_body"
+      name="body"
+      rows="4"
+      placeholder="Describe your request in detail…"
+      required
+    ></textarea>
+  </div>
+
+  <!-- ── Attachments ── -->
+  <div class="form-group">
+    <label for="consult_files">Attachments (optional)</label>
+    <input
+      type="file"
+      id="consult_files"
+      name="attachments"
+      multiple
+      accept="image/*,.pdf,.doc,.docx"
+    />
+    <small class="note">
+      You may attach images, PDFs, Word docs (up to 10 MB total).
+    </small>
+  </div>
+
+  <!-- ── Submit Button ── -->
+  <button type="submit" class="btn-primary modal-submit">
+    <i class="fa-solid fa-paper-plane"></i>
+    Send Request
+  </button>
+</form>
+
+    <!-- Success message (hidden by default) -->
+    <div id="consult_success" class="modal-success hidden">
+      <h3>Thank you!</h3>
+      <p>
+        Your consultation request has been sent. We will be in touch shortly.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+    <!-- Error message (hidden by default) -->
+    <div id="consult_error" class="modal-error hidden">
+      <h3>Oops — we hit an error</h3>
+      <!-- This <p> will get filled with the server’s error message -->
+      <p id="consult_error_message">
+        Something went wrong. Please try again later.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+  </div>
+</div>
+<!-- ─── CONSULTATION REQUEST MODAL (end) ─── -->
+
+  
 <section class="hero hero--contact">
   <div class="hero__inner">
     <h1>Let’s&nbsp;Talk</h1>
     <p class="strap">Rapid quotations&nbsp;• Same-day replies</p>
   </div>
 </section>
-{% endblock %}
 
 
-{% block content %}
+  <main>
+    
 <!-- =================  CONTACT DETAILS  ================ -->
 <section class="contact-grid">
   <!-- left column -->
@@ -47,4 +229,13 @@
     </iframe>
   </div>
 </section>
-{% endblock %}
+
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Matford Manufacturing. All rights reserved.</p>
+  </footer>
+
+  <script src="static/js/consultation-modal.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,9 +1,192 @@
-{% extends 'base.html' %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Matford Manufacturing</title>
 
-{% block hero %}
+  <!-- Your main stylesheet -->
+  <link rel="stylesheet" href="static/css/style.css" />
+
+  <!-- (optional) Google Font or Material Symbols if you still need them -->
+  <link
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400"
+    rel="stylesheet"
+  />
+
+  <!-- ─── FONT AWESOME 6.3 CDN ─── -->
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css"
+  />
+</head>
+<body>
+  <!-- ===== MASTHEAD / NAV ===== -->
+  <header class="masthead">
+    <div class="banner-inner">
+      <!-- ─── LEFT: Logo ─── -->
+      <div class="banner-logo">
+        <img
+          src="static/images/matford_logo.svg"
+          alt="Matford Manufacturing"/>
+      </div>
+        <div class="banner-cta">
+        <!-- Phone -->
+          <a class="contact-item" href="tel:+441234567890" aria-label="Call us">
+            <span class="contact-icon"><i class="fa-solid fa-phone"></i></span>
+            <span class="contact-text">+44&nbsp;1234&nbsp;567&nbsp;890</span>
+          </a>
+
+          <!-- Mail -->
+          <a class="contact-item" href="mailto:info@matfordmfg.com" aria-label="E-mail us">
+            <span class="contact-icon"><i class="fa-solid fa-envelope"></i></span>
+            <span class="contact-text">info@matfordmfg.com</span>
+          </a>
+        </div>
+    </div>
+  </header>
+
+  <!-- ─── PRIMARY NAVIGATION (Desktop) ─── -->
+  <nav>
+    <ul id="nav-menu">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+  <!-- ─── HAMBURGER TOGGLE FOR MOBILE ─── -->
+  <button class="nav-toggle" aria-label="Open navigation" aria-expanded="false">
+    <span class="nav-toggle__bar"></span>
+  </button>
+
+  <!-- ─── MOBILE DRAWER NAV ─── -->
+  <nav class="mobile-nav" aria-label="Mobile">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+ <!-- ─── CONSULTATION REQUEST MODAL (start hidden) ─── -->
+<div id="consultation-modal" class="modal-overlay hidden">
+  <div class="modal-content">
+
+    <div class="modal-brand">
+      <img src="static/images/matford_logo.svg"
+           alt="Matford Manufacturing logo" />
+    </div>
+
+    <button class="modal-close" aria-label="Close">&times;</button>
+
+    <h2>Request Free Consultation</h2>
+<form
+  id="consultForm"
+  action="#"
+  method="POST"
+  enctype="multipart/form-data"
+>
+  <!-- ── Email + Phone Side by Side ── -->
+  <div class="form-row">
+    <div class="form-group">
+      <label for="consult_email">Email address</label>
+      <input
+        type="email"
+        id="consult_email"
+        name="email"
+        placeholder="you@example.com"
+        required
+      />
+    </div>
+    <div class="form-group">
+      <label for="consult_phone">Contact number</label>
+      <input
+        type="tel"
+        id="consult_phone"
+        name="phone"
+        placeholder="+44 1234 567 890"
+      />
+    </div>
+  </div>
+
+  <!-- ── Subject ── -->
+  <div class="form-group">
+    <label for="consult_title">Subject</label>
+    <input
+      type="text"
+      id="consult_title"
+      name="title"
+      placeholder="Enter a brief subject"
+      required
+    />
+  </div>
+
+  <!-- ── Message ── -->
+  <div class="form-group">
+    <label for="consult_body">Message</label>
+    <textarea
+      id="consult_body"
+      name="body"
+      rows="4"
+      placeholder="Describe your request in detail…"
+      required
+    ></textarea>
+  </div>
+
+  <!-- ── Attachments ── -->
+  <div class="form-group">
+    <label for="consult_files">Attachments (optional)</label>
+    <input
+      type="file"
+      id="consult_files"
+      name="attachments"
+      multiple
+      accept="image/*,.pdf,.doc,.docx"
+    />
+    <small class="note">
+      You may attach images, PDFs, Word docs (up to 10 MB total).
+    </small>
+  </div>
+
+  <!-- ── Submit Button ── -->
+  <button type="submit" class="btn-primary modal-submit">
+    <i class="fa-solid fa-paper-plane"></i>
+    Send Request
+  </button>
+</form>
+
+    <!-- Success message (hidden by default) -->
+    <div id="consult_success" class="modal-success hidden">
+      <h3>Thank you!</h3>
+      <p>
+        Your consultation request has been sent. We will be in touch shortly.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+    <!-- Error message (hidden by default) -->
+    <div id="consult_error" class="modal-error hidden">
+      <h3>Oops — we hit an error</h3>
+      <!-- This <p> will get filled with the server’s error message -->
+      <p id="consult_error_message">
+        Something went wrong. Please try again later.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+  </div>
+</div>
+<!-- ─── CONSULTATION REQUEST MODAL (end) ─── -->
+
+  
 <section class="video-hero">
   <video class="video-hero__media"
-         src="{{ url_for('static', filename='video/nlx_loop_seg.mp4') }}"
+         src="static/video/nlx_loop_seg.mp4"
          autoplay muted loop playsinline
          disablepictureinpicture
          controlslist="nodownload nofullscreen noremoteplayback">
@@ -14,18 +197,19 @@
     <p class="video-hero__subtitle">
       Without sacrificing tolerance.
     </p>
-    <a href="{{ url_for('contact') }}" class="video-hero__cta">Request a Free Quote</a>
+    <a href="contact.html" class="video-hero__cta">Request a Free Quote</a>
   </div>
 </section>
-{% endblock %}
 
-{% block content %}
+
+  <main>
+    
 <!-- ── Product Heroes Under Video Hero ── -->
 <section class="product-heroes-grid">
   <!-- Hero 1 -->
   <div class="solo-hero">
     <div class="solo-hero__image">
-      <img src="{{ url_for('static', filename='images/heros/part3_circle.png') }}"
+      <img src="static/images/heros/part3_circle.png"
            alt="Supply-chain partner illustration">
     </div>
     <div class="solo-hero__copy">
@@ -37,7 +221,7 @@
   <!-- Hero 2 -->
   <div class="solo-hero">
     <div class="solo-hero__image">
-      <img src="{{ url_for('static', filename='images/heros/part4_circle.png') }}"
+      <img src="static/images/heros/part4_circle.png"
            alt="Mori NLX machines">
     </div>
     <div class="solo-hero__copy">
@@ -49,7 +233,7 @@
   <!-- Hero 3 -->
   <div class="solo-hero">
     <div class="solo-hero__image">
-      <img src="{{ url_for('static', filename='images/heros/part5_circle.png') }}"
+      <img src="static/images/heros/part5_circle.png"
            alt="Assembly kit service">
     </div>
     <div class="solo-hero__copy">
@@ -60,4 +244,13 @@
 </section>
 <!-- ── End Product Heroes ── -->
 
-{% endblock %}
+
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Matford Manufacturing. All rights reserved.</p>
+  </footer>
+
+  <script src="static/js/consultation-modal.js"></script>
+</body>
+</html>

--- a/docs/mori_machines.html
+++ b/docs/mori_machines.html
@@ -1,5 +1,192 @@
-{% extends "base.html" %}
-{% block content %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Matford Manufacturing</title>
+
+  <!-- Your main stylesheet -->
+  <link rel="stylesheet" href="static/css/style.css" />
+
+  <!-- (optional) Google Font or Material Symbols if you still need them -->
+  <link
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400"
+    rel="stylesheet"
+  />
+
+  <!-- ─── FONT AWESOME 6.3 CDN ─── -->
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css"
+  />
+</head>
+<body>
+  <!-- ===== MASTHEAD / NAV ===== -->
+  <header class="masthead">
+    <div class="banner-inner">
+      <!-- ─── LEFT: Logo ─── -->
+      <div class="banner-logo">
+        <img
+          src="static/images/matford_logo.svg"
+          alt="Matford Manufacturing"/>
+      </div>
+        <div class="banner-cta">
+        <!-- Phone -->
+          <a class="contact-item" href="tel:+441234567890" aria-label="Call us">
+            <span class="contact-icon"><i class="fa-solid fa-phone"></i></span>
+            <span class="contact-text">+44&nbsp;1234&nbsp;567&nbsp;890</span>
+          </a>
+
+          <!-- Mail -->
+          <a class="contact-item" href="mailto:info@matfordmfg.com" aria-label="E-mail us">
+            <span class="contact-icon"><i class="fa-solid fa-envelope"></i></span>
+            <span class="contact-text">info@matfordmfg.com</span>
+          </a>
+        </div>
+    </div>
+  </header>
+
+  <!-- ─── PRIMARY NAVIGATION (Desktop) ─── -->
+  <nav>
+    <ul id="nav-menu">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+  <!-- ─── HAMBURGER TOGGLE FOR MOBILE ─── -->
+  <button class="nav-toggle" aria-label="Open navigation" aria-expanded="false">
+    <span class="nav-toggle__bar"></span>
+  </button>
+
+  <!-- ─── MOBILE DRAWER NAV ─── -->
+  <nav class="mobile-nav" aria-label="Mobile">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+ <!-- ─── CONSULTATION REQUEST MODAL (start hidden) ─── -->
+<div id="consultation-modal" class="modal-overlay hidden">
+  <div class="modal-content">
+
+    <div class="modal-brand">
+      <img src="static/images/matford_logo.svg"
+           alt="Matford Manufacturing logo" />
+    </div>
+
+    <button class="modal-close" aria-label="Close">&times;</button>
+
+    <h2>Request Free Consultation</h2>
+<form
+  id="consultForm"
+  action="#"
+  method="POST"
+  enctype="multipart/form-data"
+>
+  <!-- ── Email + Phone Side by Side ── -->
+  <div class="form-row">
+    <div class="form-group">
+      <label for="consult_email">Email address</label>
+      <input
+        type="email"
+        id="consult_email"
+        name="email"
+        placeholder="you@example.com"
+        required
+      />
+    </div>
+    <div class="form-group">
+      <label for="consult_phone">Contact number</label>
+      <input
+        type="tel"
+        id="consult_phone"
+        name="phone"
+        placeholder="+44 1234 567 890"
+      />
+    </div>
+  </div>
+
+  <!-- ── Subject ── -->
+  <div class="form-group">
+    <label for="consult_title">Subject</label>
+    <input
+      type="text"
+      id="consult_title"
+      name="title"
+      placeholder="Enter a brief subject"
+      required
+    />
+  </div>
+
+  <!-- ── Message ── -->
+  <div class="form-group">
+    <label for="consult_body">Message</label>
+    <textarea
+      id="consult_body"
+      name="body"
+      rows="4"
+      placeholder="Describe your request in detail…"
+      required
+    ></textarea>
+  </div>
+
+  <!-- ── Attachments ── -->
+  <div class="form-group">
+    <label for="consult_files">Attachments (optional)</label>
+    <input
+      type="file"
+      id="consult_files"
+      name="attachments"
+      multiple
+      accept="image/*,.pdf,.doc,.docx"
+    />
+    <small class="note">
+      You may attach images, PDFs, Word docs (up to 10 MB total).
+    </small>
+  </div>
+
+  <!-- ── Submit Button ── -->
+  <button type="submit" class="btn-primary modal-submit">
+    <i class="fa-solid fa-paper-plane"></i>
+    Send Request
+  </button>
+</form>
+
+    <!-- Success message (hidden by default) -->
+    <div id="consult_success" class="modal-success hidden">
+      <h3>Thank you!</h3>
+      <p>
+        Your consultation request has been sent. We will be in touch shortly.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+    <!-- Error message (hidden by default) -->
+    <div id="consult_error" class="modal-error hidden">
+      <h3>Oops — we hit an error</h3>
+      <!-- This <p> will get filled with the server’s error message -->
+      <p id="consult_error_message">
+        Something went wrong. Please try again later.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+  </div>
+</div>
+<!-- ─── CONSULTATION REQUEST MODAL (end) ─── -->
+
+  
+
+  <main>
+    
 
 <!-- ─── Mori Machines “Super-Hero” ─────────────────────────── -->
 <section class="mori-hero">
@@ -39,4 +226,13 @@
 </section>
 <!-- ─── End Mori-Machines hero ─────────────────────────────── -->
 
-{% endblock %}
+
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Matford Manufacturing. All rights reserved.</p>
+  </footer>
+
+  <script src="static/js/consultation-modal.js"></script>
+</body>
+</html>

--- a/docs/services.html
+++ b/docs/services.html
@@ -1,6 +1,192 @@
-{% extends 'base.html' %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Matford Manufacturing</title>
 
-{% block content %}
+  <!-- Your main stylesheet -->
+  <link rel="stylesheet" href="static/css/style.css" />
+
+  <!-- (optional) Google Font or Material Symbols if you still need them -->
+  <link
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400"
+    rel="stylesheet"
+  />
+
+  <!-- ─── FONT AWESOME 6.3 CDN ─── -->
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css"
+  />
+</head>
+<body>
+  <!-- ===== MASTHEAD / NAV ===== -->
+  <header class="masthead">
+    <div class="banner-inner">
+      <!-- ─── LEFT: Logo ─── -->
+      <div class="banner-logo">
+        <img
+          src="static/images/matford_logo.svg"
+          alt="Matford Manufacturing"/>
+      </div>
+        <div class="banner-cta">
+        <!-- Phone -->
+          <a class="contact-item" href="tel:+441234567890" aria-label="Call us">
+            <span class="contact-icon"><i class="fa-solid fa-phone"></i></span>
+            <span class="contact-text">+44&nbsp;1234&nbsp;567&nbsp;890</span>
+          </a>
+
+          <!-- Mail -->
+          <a class="contact-item" href="mailto:info@matfordmfg.com" aria-label="E-mail us">
+            <span class="contact-icon"><i class="fa-solid fa-envelope"></i></span>
+            <span class="contact-text">info@matfordmfg.com</span>
+          </a>
+        </div>
+    </div>
+  </header>
+
+  <!-- ─── PRIMARY NAVIGATION (Desktop) ─── -->
+  <nav>
+    <ul id="nav-menu">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+  <!-- ─── HAMBURGER TOGGLE FOR MOBILE ─── -->
+  <button class="nav-toggle" aria-label="Open navigation" aria-expanded="false">
+    <span class="nav-toggle__bar"></span>
+  </button>
+
+  <!-- ─── MOBILE DRAWER NAV ─── -->
+  <nav class="mobile-nav" aria-label="Mobile">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="services.html">Services</a></li>
+      <li><a href="mori_machines.html">Mori Machines</a></li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </nav>
+
+ <!-- ─── CONSULTATION REQUEST MODAL (start hidden) ─── -->
+<div id="consultation-modal" class="modal-overlay hidden">
+  <div class="modal-content">
+
+    <div class="modal-brand">
+      <img src="static/images/matford_logo.svg"
+           alt="Matford Manufacturing logo" />
+    </div>
+
+    <button class="modal-close" aria-label="Close">&times;</button>
+
+    <h2>Request Free Consultation</h2>
+<form
+  id="consultForm"
+  action="#"
+  method="POST"
+  enctype="multipart/form-data"
+>
+  <!-- ── Email + Phone Side by Side ── -->
+  <div class="form-row">
+    <div class="form-group">
+      <label for="consult_email">Email address</label>
+      <input
+        type="email"
+        id="consult_email"
+        name="email"
+        placeholder="you@example.com"
+        required
+      />
+    </div>
+    <div class="form-group">
+      <label for="consult_phone">Contact number</label>
+      <input
+        type="tel"
+        id="consult_phone"
+        name="phone"
+        placeholder="+44 1234 567 890"
+      />
+    </div>
+  </div>
+
+  <!-- ── Subject ── -->
+  <div class="form-group">
+    <label for="consult_title">Subject</label>
+    <input
+      type="text"
+      id="consult_title"
+      name="title"
+      placeholder="Enter a brief subject"
+      required
+    />
+  </div>
+
+  <!-- ── Message ── -->
+  <div class="form-group">
+    <label for="consult_body">Message</label>
+    <textarea
+      id="consult_body"
+      name="body"
+      rows="4"
+      placeholder="Describe your request in detail…"
+      required
+    ></textarea>
+  </div>
+
+  <!-- ── Attachments ── -->
+  <div class="form-group">
+    <label for="consult_files">Attachments (optional)</label>
+    <input
+      type="file"
+      id="consult_files"
+      name="attachments"
+      multiple
+      accept="image/*,.pdf,.doc,.docx"
+    />
+    <small class="note">
+      You may attach images, PDFs, Word docs (up to 10 MB total).
+    </small>
+  </div>
+
+  <!-- ── Submit Button ── -->
+  <button type="submit" class="btn-primary modal-submit">
+    <i class="fa-solid fa-paper-plane"></i>
+    Send Request
+  </button>
+</form>
+
+    <!-- Success message (hidden by default) -->
+    <div id="consult_success" class="modal-success hidden">
+      <h3>Thank you!</h3>
+      <p>
+        Your consultation request has been sent. We will be in touch shortly.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+    <!-- Error message (hidden by default) -->
+    <div id="consult_error" class="modal-error hidden">
+      <h3>Oops — we hit an error</h3>
+      <!-- This <p> will get filled with the server’s error message -->
+      <p id="consult_error_message">
+        Something went wrong. Please try again later.
+      </p>
+      <button class="btn-primary modal-close">Close</button>
+    </div>
+
+  </div>
+</div>
+<!-- ─── CONSULTATION REQUEST MODAL (end) ─── -->
+
+  
+
+  <main>
+    
   <!-- Services hero -->
   <section class="services-hero">
     <!-- tinted background is handled in CSS, so this div is optional -->
@@ -34,4 +220,13 @@
       </div>
     </div>
   </section>
-{% endblock %}
+
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Matford Manufacturing. All rights reserved.</p>
+  </footer>
+
+  <script src="static/js/consultation-modal.js"></script>
+</body>
+</html>

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -25,7 +25,7 @@
     background:
         /* blue overlay on top of photo */
         linear-gradient(to right, rgba(10,61,98,.9), rgba(10,61,98,.7)),
-        url('/static/images/Mori_home_bg.jpg')  center / cover no-repeat;
+        url('static/images/Mori_home_bg.jpg')  center / cover no-repeat;
     color: #fff;
 }
 
@@ -191,8 +191,8 @@ main p {
 }
 
 /* individual background paths */
-.hero-section       {background-image:url('/static/images/mori_operator_panel.webp');}
-.contact-hero       {background-image:url('/static/images/loading_image_v2.webp') !important;}
+.hero-section       {background-image:url('static/images/mori_operator_panel.webp');}
+.contact-hero       {background-image:url('static/images/loading_image_v2.webp') !important;}
 
 /* shared overlay */
 .overlay{
@@ -761,7 +761,7 @@ main > .video-hero {
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   background:
     linear-gradient(rgba(10, 61, 98, 0.88), rgba(10, 61, 98, 0.88)),
-    url('/static/images/hero_bg1.png') center / cover no-repeat;
+    url('static/images/hero_bg1.png') center / cover no-repeat;
 }
 
 /* Default image size (heroes 1 & 3) */
@@ -982,7 +982,7 @@ main {
   /* brand-blue overlay + photo */
   background:
     linear-gradient(rgba(10,61,98,.90),rgba(10,61,98,.70)),
-    url('/static/images/services_bg.webp') center / cover no-repeat;
+    url('static/images/services_bg.webp') center / cover no-repeat;
 }
 
 .services-hero_content{
@@ -1049,7 +1049,7 @@ main {
   /* blue tint + photo */
   background:
     linear-gradient(rgba(10,61,98,.90),rgba(10,61,98,.70)),
-    url('/static/images/services_bg.webp') center / cover no-repeat;
+    url('static/images/services_bg.webp') center / cover no-repeat;
 }
 
 /* inner wrapper keeps text from hugging edges and centres card */
@@ -1138,7 +1138,7 @@ main {
     box-shadow: 0 6px 20px rgba(0,0,0,.25);
     background:
         linear-gradient(rgba(10,61,98,.88),rgba(10,61,98,.88)),
-        url('/static/images/mori_page_bg.jpg') center/cover no-repeat;
+        url('static/images/mori_page_bg.jpg') center/cover no-repeat;
 }
 
 /* keeps white rails consistent with other pages */
@@ -1204,7 +1204,7 @@ main {
   /* blue overlay + machine photo */
   background:
     linear-gradient(rgba(10,61,98,.88),rgba(10,61,98,.88)),
-    url("/static/images/mori_page_bg.jpg") center/cover no-repeat;
+    url("static/images/mori_page_bg.jpg") center/cover no-repeat;
 }
 
 .mori-hero_content{
@@ -1841,7 +1841,7 @@ main > .mori-hero{
      custom --hero-img isn’t present for some reason) */
   background:
     linear-gradient(rgba(10,61,98,.88), rgba(10,61,98,.88)),
-    var(--hero-img, url('/static/images/hero_bg1.png'))  /*  fallback  */
+    var(--hero-img, url('static/images/hero_bg1.png'))  /*  fallback  */
       center / cover no-repeat;
 }
 
@@ -1860,7 +1860,7 @@ main > .mori-hero{
       rgba(10, 61, 98, 0.75),   /* top */
       rgba(10,61,98,0.75)    /* bottom */
     ),
-    var(--hero-img, url('/static/images/hero_bg1.png')) center / cover no-repeat;
+    var(--hero-img, url('static/images/hero_bg1.png')) center / cover no-repeat;
 }
 
 /* ─── About page heading colours ─── */
@@ -1909,7 +1909,7 @@ main > .mori-hero{
   text-align:center;
   color:var(--white);
   background:linear-gradient(rgba(10,61,98,.75), rgba(10,61,98,.75)),
-             url("/static/images/hero_bg1.png") center/cover no-repeat;
+             url("static/images/hero_bg1.png") center/cover no-repeat;
 }
 .contact-hero h1{font-size:clamp(2.5rem,6vw,3.5rem); margin:0;}
 .contact-hero .strap{font-size:1.1rem; margin-top:.75rem; letter-spacing:.5px}
@@ -1961,7 +1961,7 @@ main > .mori-hero{
         rgba(10,61,98,.75)
       ),
       /* hero photo */
-      url("/static/images/about2.jpg") center/cover no-repeat;
+      url("static/images/about2.jpg") center/cover no-repeat;
 }
 .hero--contact .strap{
   font-size:1.125rem;


### PR DESCRIPTION
## Summary
- render HTML templates to plain files under `docs`
- use relative links for assets and pages
- update CSS URLs to use relative `static/` path

## Testing
- `python render_templates.py` *(local build step used then removed)*

------
https://chatgpt.com/codex/tasks/task_e_685bd992fd948320bad917605c7d074b