### PR TITLE
Fix static paths for hero images

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,8 @@ load_dotenv()
 
 # ─── CONFIGURATION ────────────────────────────────────────────────────────────────
 
-app = Flask(__name__, static_folder="static")
+# Serve templates from the 'docs' folder and static files from 'docs/static'
+app = Flask(__name__, static_folder="docs/static", template_folder="docs")
 # Used for flashing messages if needed
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "change_this_to_a_random_key")
 


### PR DESCRIPTION
## Summary
- configure Flask app to load templates from `docs` and assets from `docs/static`

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685bdbc53b708320a3d863dbf610ffae