### PR TITLE
Enlarge contact page map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Matford Manufacturing Website
+
+This repository contains a Flask-based website for Matford Manufacturing. It includes multiple pages (Home, About, Services, Mori Machines, Contact) and assets in the static directory. The site demonstrates product heroes, contact forms and a Google Maps embed.
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1937,7 +1937,7 @@ main > .mori-hero{
 .contact-card .hours{list-style:none; padding:0; margin:0}
 .contact-card .hours li{margin:.25rem 0}
 .map-wrap{
-  min-height:360px;
+  min-height:540px; /* increased from 360px to give the map more presence */
   border-radius:.75rem;
   overflow:hidden;
   box-shadow:0 6px 20px rgba(0,0,0,.12);


### PR DESCRIPTION
## Summary
- document project details in README
- increase the map's minimum height to occupy more space on the contact page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d723da4008320bc9d87f7017231a4