### PR TITLE
Add Flask static export scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+static_export/

--- a/export_static.py
+++ b/export_static.py
@@ -1,0 +1,106 @@
+import os
+import shutil
+from bs4 import BeautifulSoup
+from app import app
+
+BINARY_EXTENSIONS = {
+    '.db', '.pyc', '.pkl', '.exe', '.bin', '.mov', '.mp4', '.mkv', '.avi', '.ogg',
+    '.wav', '.zip', '.tar', '.gz'
+}
+
+# Mapping of static relative paths that were moved to the bin directory.
+BINARY_MAP = {}
+
+
+def is_binary(filename: str) -> bool:
+    return os.path.splitext(filename)[1].lower() in BINARY_EXTENSIONS
+
+
+def rewrite_links(html: str) -> str:
+    soup = BeautifulSoup(html, 'html.parser')
+
+    for tag in soup.find_all('a'):
+        href = tag.get('href')
+        if href and href.startswith('/') and '://' not in href:
+            path = href.split('#')[0].split('?')[0].rstrip('/')
+            filename = 'index.html' if path == '' else path.lstrip('/') + '.html'
+            tag['href'] = filename
+    for tag in soup.find_all(['script', 'img', 'source', 'video']):
+        src = tag.get('src')
+        if src and src.startswith('/static'):
+            rel = src[len('/static/'):]
+            if rel in BINARY_MAP:
+                tag['src'] = BINARY_MAP[rel]
+            else:
+                tag['src'] = src.lstrip('/')
+    for tag in soup.find_all('link'):
+        href = tag.get('href')
+        if href and href.startswith('/static'):
+            rel = href[len('/static/'):]
+            if rel in BINARY_MAP:
+                tag['href'] = BINARY_MAP[rel]
+            else:
+                tag['href'] = href.lstrip('/')
+    return str(soup)
+
+
+def export(output_dir='static_export'):
+    global BINARY_MAP
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    os.makedirs(output_dir)
+    static_out = os.path.join(output_dir, 'static')
+    bin_out = os.path.join(output_dir, 'bin')
+    os.makedirs(static_out)
+    os.makedirs(bin_out)
+
+    moved_binaries = []
+
+    # Copy static files
+    for root, _, files in os.walk(app.static_folder):
+        for f in files:
+            src_path = os.path.join(root, f)
+            rel_path = os.path.relpath(src_path, app.static_folder)
+            if is_binary(f):
+                dest = os.path.join(bin_out, rel_path)
+                moved_binaries.append(rel_path)
+                BINARY_MAP[rel_path] = os.path.join('bin', rel_path)
+            else:
+                dest = os.path.join(static_out, rel_path)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            shutil.copy2(src_path, dest)
+
+    # Render routes
+    client = app.test_client()
+    for rule in app.url_map.iter_rules():
+        if 'GET' not in rule.methods or rule.arguments:
+            continue
+        path = rule.rule.rstrip('/')
+        filename = 'index.html' if path == '' else path.lstrip('/') + '.html'
+        try:
+            resp = client.get(rule.rule)
+        except Exception as e:
+            print(f"Skipping {rule.rule}: {e}")
+            continue
+        if resp.status_code != 200:
+            print(f"Skipping {rule.rule}: status {resp.status_code}")
+            continue
+        html = resp.get_data(as_text=True)
+        html = rewrite_links(html)
+        out_path = os.path.join(output_dir, filename)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, 'w', encoding='utf-8') as fh:
+            fh.write(html)
+        if '<form' in html:
+            print(f"Warning: {filename} contains a form which will not submit sta"
+                  "tically.")
+
+    # Report moved binaries
+    if moved_binaries:
+        print('Moved binary files to /bin:')
+        for m in moved_binaries:
+            print('  ', m)
+
+
+if __name__ == '__main__':
+    export()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ packaging==25.0
 python-dotenv==1.1.0
 Werkzeug==3.1.3
 youtube-dl==2021.12.17
+beautifulsoup4==4.12.2

--- a/static/js/consultation-modal.js
+++ b/static/js/consultation-modal.js
@@ -1,0 +1,1 @@
+// placeholder

--- a/test_static_export.py
+++ b/test_static_export.py
@@ -1,0 +1,52 @@
+import os
+import unittest
+from bs4 import BeautifulSoup
+from app import app
+
+OUTPUT_DIR = 'static_export'
+BINARY_EXTENSIONS = {
+    '.db', '.pyc', '.pkl', '.exe', '.bin', '.mov', '.mp4', '.mkv', '.avi', '.ogg',
+    '.wav', '.zip', '.tar', '.gz'
+}
+
+class StaticExportTests(unittest.TestCase):
+    def test_pages_exist(self):
+        client = app.test_client()
+        for rule in app.url_map.iter_rules():
+            if 'GET' not in rule.methods or rule.arguments:
+                continue
+            resp = client.get(rule.rule)
+            if resp.status_code != 200:
+                continue
+            path = rule.rule.rstrip('/')
+            filename = 'index.html' if path == '' else path.lstrip('/') + '.html'
+            file_path = os.path.join(OUTPUT_DIR, filename)
+            self.assertTrue(os.path.isfile(file_path), f'Missing {file_path}')
+
+    def test_links_resolve(self):
+        for root, _, files in os.walk(OUTPUT_DIR):
+            for f in files:
+                if not f.endswith('.html'):
+                    continue
+                fp = os.path.join(root, f)
+                with open(fp, encoding='utf-8') as html_file:
+                    soup = BeautifulSoup(html_file, 'html.parser')
+                for tag in soup.find_all(['a', 'img', 'script', 'link', 'source', 'video']):
+                    attr = 'href' if tag.name in ['a', 'link'] else 'src'
+                    url = tag.get(attr)
+                    if (not url or url.startswith(('http', 'mailto:', 'tel:'))
+                            or url.startswith('javascript:')):
+                        continue
+                    url = url.split('#')[0].split('?')[0]
+                    resource_path = os.path.join(OUTPUT_DIR, url)
+                    self.assertTrue(os.path.exists(resource_path), f'{url} referenced in {f} is missing')
+
+    def test_no_binaries_in_static_root(self):
+        static_root = os.path.join(OUTPUT_DIR, 'static')
+        for root, _, files in os.walk(static_root):
+            for f in files:
+                if os.path.splitext(f)[1].lower() in BINARY_EXTENSIONS:
+                    self.fail(f'Binary file {f} found in static; should be in bin/')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add export_static.py script to render Flask site as static HTML
- rewrite links and move binaries to `bin/`
- add placeholder JavaScript
- add automated tests in test_static_export.py
- update dependencies and `.gitignore`

## Testing
- `python export_static.py`
- `python test_static_export.py`

------
https://chatgpt.com/codex/tasks/task_e_6861325236a88320b74cd3ba99729f4d